### PR TITLE
Updated docs to include container setup instructions for other service providers

### DIFF
--- a/docs/src/pages/mining.mdx
+++ b/docs/src/pages/mining.mdx
@@ -28,6 +28,40 @@ https://cloud.jarvislabs.ai
 
 This will take approximately 10 minutes to boot, until then the API link will not work. You can check that it has booted by clicking the API link for the instance, when the docs page shows up that means it has booted.
 
+<details>
+<summary>Other providers</summary>
+
+Community members have also managed to run the model on other cloud gpus such as [RunPod](https://www.runpod.io/) and [Vast](https://vast.ai/).
+
+### RunPod
+You need to create a new GPU Pod with the Docker image.
+1. Create a new A100 GPU Pod and click deploy.
+2. Customize Deployment
+  i. Set the Docker Image to `r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5`
+  ii. Set the Storage to `60GB`
+  iii. Expose HTTP port `5000` if you wish to run the miner script on a different server.
+  iv. Set Overrides
+3. Click Continue and then Deploy.
+4. Go to pods page and wait for the pod to be ready and for the model to be downloaded then connect to the server either using the web terminal or ssh using the provided credentials.
+5. Setup mining software using the instructions found below.
+
+### Vast
+
+<Note>At the time of writing, the Vast GUI is broken and doesn't allow pasting the Docker image correctly and so you must use the GUI.</Note>
+
+1. Download Vast CLI from [here](https://cloud.vast.ai/cli/)
+2. Find a suitable instance using the GUI or the website and note it's id (found in the bottom left as `Type #<id>`).
+3. Run the following command after installing the Vast CLI, replacing `<instance-id>` with the number noted down earlier:
+
+<Note>Dependig on how you installed the Vast CLI you may need to replace `/.vast` with `vastai`.</Note>
+
+> ```bash
+> ./vast create instance <instance-id> --image r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5 --env '-p 5000:5000 -p 22:22' --onstart-cmd 'python -m cog.server.http' --jupyter-dir /src --ssh --direct --disk 100
+> ```
+
+5. Setup mining software using the instructions found below.
+</details>
+
 ## Setup Mining Software and Dependencies
 
 You may run the mining software on a local machine or on a cloud instance. Especially if using a cloud instance, ensure that you properly secure the machine.


### PR DESCRIPTION
## Summary

Many people in the Miner's telegram chat were asking for help on setting up the container on other service providers. I've updated the docs to include instructions for two of those which I and other community members have tested and have working which are Runpod and Vast

## Test

Only changed docs, no tests needed. Just need to see how it looks. It may need to be modified to follow the rest of the docs conventions.