### PR TITLE
Runpod instructions sublist was improperly formatted

### DIFF
--- a/docs/src/pages/mining.mdx
+++ b/docs/src/pages/mining.mdx
@@ -34,30 +34,30 @@ This will take approximately 10 minutes to boot, until then the API link will no
 Community members have also managed to run the model on other cloud gpus such as [RunPod](https://www.runpod.io/) and [Vast](https://vast.ai/).
 
 ### RunPod
-You need to create a new GPU Pod with the Docker image
-1. Create a new A100 GPU Pod and click deploy
-2. Customize Deployment
-  1. Set the Docker Image to `r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5`
-  2. Set the Storage to `60GB`
-  3. Expose HTTP port `5000` if you wish to run the miner script on a different server
-  4. Set Overrides
-3. Click Continue and then Deploy
-4. Go to pods page and wait for the pod to be ready and for the model to be downloaded then connect to the server either using the web terminal or ssh using the provided credentials
-5. Setup mining software using the instructions found below
+You need to create a new GPU Pod with the Docker image.
+1. Create a new A100 GPU Pod and click deploy.
+2. Customize Deployment.
+  1. Set the Docker Image to `r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5`.
+  2. Set the Storage to `60GB`.
+  3. Expose HTTP port `5000` if you wish to run the miner script on a different server.
+  4. Set Overrides.
+3. Click Continue and then Deploy.
+4. Go to pods page and wait for the pod to be ready and for the model to be downloaded then connect to the server either using the web terminal or ssh using the provided credentials.
+5. Setup mining software using the instructions found below.
 
 ### Vast
 
 <Note>At the time of writing, the Vast GUI is broken and doesn't allow pasting the Docker image correctly and so you must use the GUI.</Note>
 
-1. Download Vast CLI from [here](https://cloud.vast.ai/cli/)
-2. Find a suitable instance using the GUI or the website and note it's id (found in the bottom left as `Type #<id>`)
+1. Download Vast CLI from [here](https://cloud.vast.ai/cli/).
+2. Find a suitable instance using the GUI or the website and note it's id (found in the bottom left as `Type #<id>`).
 3. Run the following command after installing the Vast CLI, replacing `<instance-id>` with the number noted down earlier:
 
-<Note>Dependig on how you installed the Vast CLI you may need to replace `/.vast` with `vastai`.</Note>
+```bash
+./vast create instance <instance-id> --image r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5 --env '-p 5000:5000 -p 22:22' --onstart-cmd 'python -m cog.server.http' --jupyter-dir /src --ssh --direct --disk 100
+```
 
-> ```bash
-> ./vast create instance <instance-id> --image r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5 --env '-p 5000:5000 -p 22:22' --onstart-cmd 'python -m cog.server.http' --jupyter-dir /src --ssh --direct --disk 100
-> ```
+<Note>Dependig on how you installed the Vast CLI you may need to replace `/.vast` with `vastai`.</Note>
 
 5. Setup mining software using the instructions found below.
 </details>

--- a/docs/src/pages/mining.mdx
+++ b/docs/src/pages/mining.mdx
@@ -37,10 +37,10 @@ Community members have also managed to run the model on other cloud gpus such as
 You need to create a new GPU Pod with the Docker image.
 1. Create a new A100 GPU Pod and click deploy.
 2. Customize Deployment
-  i. Set the Docker Image to `r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5`
-  ii. Set the Storage to `60GB`
-  iii. Expose HTTP port `5000` if you wish to run the miner script on a different server.
-  iv. Set Overrides
+  1. Set the Docker Image to `r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5`
+  2. Set the Storage to `60GB`
+  3. Expose HTTP port `5000` if you wish to run the miner script on a different server.
+  4. Set Overrides
 3. Click Continue and then Deploy.
 4. Go to pods page and wait for the pod to be ready and for the model to be downloaded then connect to the server either using the web terminal or ssh using the provided credentials.
 5. Setup mining software using the instructions found below.

--- a/docs/src/pages/mining.mdx
+++ b/docs/src/pages/mining.mdx
@@ -34,23 +34,23 @@ This will take approximately 10 minutes to boot, until then the API link will no
 Community members have also managed to run the model on other cloud gpus such as [RunPod](https://www.runpod.io/) and [Vast](https://vast.ai/).
 
 ### RunPod
-You need to create a new GPU Pod with the Docker image.
-1. Create a new A100 GPU Pod and click deploy.
+You need to create a new GPU Pod with the Docker image
+1. Create a new A100 GPU Pod and click deploy
 2. Customize Deployment
   1. Set the Docker Image to `r8.im/kasumi-1/kandinsky-2@sha256:373fa540ae197fc89f0679ed835bc4524152956d4f3027580244e10b09d6d3a5`
   2. Set the Storage to `60GB`
-  3. Expose HTTP port `5000` if you wish to run the miner script on a different server.
+  3. Expose HTTP port `5000` if you wish to run the miner script on a different server
   4. Set Overrides
-3. Click Continue and then Deploy.
-4. Go to pods page and wait for the pod to be ready and for the model to be downloaded then connect to the server either using the web terminal or ssh using the provided credentials.
-5. Setup mining software using the instructions found below.
+3. Click Continue and then Deploy
+4. Go to pods page and wait for the pod to be ready and for the model to be downloaded then connect to the server either using the web terminal or ssh using the provided credentials
+5. Setup mining software using the instructions found below
 
 ### Vast
 
 <Note>At the time of writing, the Vast GUI is broken and doesn't allow pasting the Docker image correctly and so you must use the GUI.</Note>
 
 1. Download Vast CLI from [here](https://cloud.vast.ai/cli/)
-2. Find a suitable instance using the GUI or the website and note it's id (found in the bottom left as `Type #<id>`).
+2. Find a suitable instance using the GUI or the website and note it's id (found in the bottom left as `Type #<id>`)
 3. Run the following command after installing the Vast CLI, replacing `<instance-id>` with the number noted down earlier:
 
 <Note>Dependig on how you installed the Vast CLI you may need to replace `/.vast` with `vastai`.</Note>


### PR DESCRIPTION
## Summary

Fixed an issue with https://github.com/semperai/arbius/pull/10 where the sublist was improperly formatted and showed the instructions in a single line. I also added full stops to the ends of the points and swapped the order of the vast cli command and the note regarding it.