### PR TITLE
Fix small typos, broken link

### DIFF
--- a/docs/src/pages/quickstart.mdx
+++ b/docs/src/pages/quickstart.mdx
@@ -7,14 +7,14 @@ The core to Arbius is a decentralized machine learning platform. Imagine Midjour
 
 ## Generate
 
-To quicky test Arbius out, you can try doing a generation. Head over to [the generate](https://arbius.ai/generate) page and try to make some images. You will need to connect your wallet via Metamask, and have tiny bit of ETH on Arbitrum Nova to connect your wallet to the contract.
+To quickly test Arbius out, you can try doing a generation. Head over to [the generate](https://arbius.ai/generate) page and try to make some images. You will need to connect your wallet via Metamask, and have tiny bit of ETH on Arbitrum Nova to connect your wallet to the contract.
 
 To use Arbitrum Nova, you will want to [bridge](https://bridge.arbitrum.io/?destinationChain=arbitrum-nova&sourceChain=ethereum) some ETH over to Arbitrum Nova.
 
 You start by choosing a model, for this we'll use `Kandinsky 2`. Select it in the dropdown, then in the prompt textbox input whatever you imagine. Try something such as "a cat looking at the moon". For now, it should be possible to get tasks mined for free, but in the future you'd want to send some AIUS along with your request so that miners will prioritize your generation.
 
 <Note>
-  You will need an Ethereum compatible wallet. [Brave wallet](https://brave.com/) and [MetaMask](https://metamask.io/) and both good options.
+  You will need an Ethereum compatible wallet. [Brave wallet](https://brave.com/) and [MetaMask](https://metamask.io/) are both good options.
 </Note>
 
 ## Explore

--- a/docs/src/pages/security.mdx
+++ b/docs/src/pages/security.mdx
@@ -6,7 +6,7 @@ Arbius is committed to the security of its protocol. We have undergone a securit
  
 **January 2024: 0xGuard**
 
-**0xGuard** has completed a security audit of the Arbius Protocol. The final audit report can be found [here](/Arbius-Protocol_final-audit.pdf).
+**0xGuard** has completed a security audit of the Arbius Protocol. The final audit report can be found [here](https://portfolio.0xguard.com/581).
 
 ## Bug Bounty Program
 


### PR DESCRIPTION
Fixed some typos + the link to the security audit is broken, so I replaced it with a working link from the website of 0xguard itself 