### PR TITLE
Fix potential runtime errors when window.ethereum is undefined

### DIFF
--- a/website2/src/lib/arbius-wallet/components/AAWalletProvider.tsx
+++ b/website2/src/lib/arbius-wallet/components/AAWalletProvider.tsx
@@ -62,13 +62,18 @@ export const AAWalletProvider: React.FC<AAWalletProviderProps> = ({ children }) 
       const chainId = parseInt(chainIdHex, 16);
       dispatch({ type: WALLET_SWITCH_CHAIN, payload: chainId });
     };
-    
-    window.ethereum.on('accountsChanged', handleAccountsChanged);
-    window.ethereum.on('chainChanged', handleChainChanged);
-    
+
+    const ethereum = window.ethereum;
+    if (ethereum && typeof ethereum.on === 'function') {
+      ethereum.on('accountsChanged', handleAccountsChanged);
+      ethereum.on('chainChanged', handleChainChanged);
+    }
+
     return () => {
-      window.ethereum?.removeListener('accountsChanged', handleAccountsChanged);
-      window.ethereum?.removeListener('chainChanged', handleChainChanged);
+      if (ethereum && typeof ethereum.removeListener === 'function') {
+        ethereum.removeListener('accountsChanged', handleAccountsChanged);
+        ethereum.removeListener('chainChanged', handleChainChanged);
+      }
     };
   }, []);
   


### PR DESCRIPTION
Added checks to ensure window.ethereum exists and has the expected methods before calling .on() or .removeListener(). This prevents TypeError crashes when the Ethereum provider is not available or incompletely loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents runtime errors when no Ethereum provider is available or when the provider lacks expected event APIs.
  * Improves stability by safely handling account and network change listeners only when supported.
  * Ensures clean removal of listeners without errors in incompatible environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->