### PR TITLE
Fix broken link in quickstart guide

### DIFF
--- a/docs/src/app/quickstart/page.mdx
+++ b/docs/src/app/quickstart/page.mdx
@@ -48,7 +48,7 @@ Are you a machine learning researcher, someone who makes fine-tunes, or someone 
 
 Do you have a dapp, marketplace, social media site, or some other idea that could benefit from decentralized machine learning?
 
-[Read the full guide](/integrate)
+[Read the full guide](/integration)
 
 ## Governance
 


### PR DESCRIPTION
The link to the integration guide was pointing to "/integrate" instead of the correct path "/integration". This caused a 404 error when users clicked the link.